### PR TITLE
feat: .zip file selection UI for update, update process window v1 and data backup POC 

### DIFF
--- a/ViewModels/ServerControlViewModel.cs
+++ b/ViewModels/ServerControlViewModel.cs
@@ -3,8 +3,13 @@ using System.Reactive;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Platform.Storage;
 using BLIS_NG.Server;
+using BLIS_NG.Config;
 using Microsoft.Extensions.Logging;
 using ReactiveUI;
+using System.IO;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace BLIS_NG.ViewModels;
 
@@ -127,7 +132,6 @@ public class ServerControlViewModel : ViewModelBase
         if (Avalonia.Application.Current?.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop 
             && desktop.MainWindow != null)
         {
-            // Access the StorageProvider from the TopLevel (Window)
             var topLevel = Avalonia.Controls.TopLevel.GetTopLevel(desktop.MainWindow);
             if (topLevel != null)
             {
@@ -146,9 +150,13 @@ public class ServerControlViewModel : ViewModelBase
 
                 if (files.Count > 0)
                 {
-                    var selectedPath = files[0].Path.LocalPath;
-                    logger.LogInformation("User selected ZIP file: {FilePath}", selectedPath);
-                    // The file path is now available in selectedPath for your logic
+                    // Trigger the automated backup within the base directory
+                    CreateAutomatedDatabaseBackup();
+
+                    string selectedFile = files[0].Path.LocalPath;
+                    logger.LogInformation("Zip file selected: {FilePath}. Automated database backup initiated.", selectedFile);
+                    
+                    // Proceed with update/extraction logic here
                 }
             }
         }
@@ -159,5 +167,53 @@ public class ServerControlViewModel : ViewModelBase
         // Shutdown server when closing
         HandleStopButtonClick();
     }
-}
 
+    private void CreateAutomatedDatabaseBackup()
+    {
+        // 1. Resolve the Base Directory and define paths
+        string baseDir = ConfigurationFile.ResolveBaseDirectory();
+        string dbSource = Path.Combine(baseDir, "dbdir");
+        
+        // 2. Create the backup path: [BaseDir]/backups/DB_Backup_[Timestamp]
+        string timestamp = DateTime.Now.ToString("yyyyMMdd_HHmmss");
+        string backupRoot = Path.Combine(baseDir, "backups");
+        string fullDestination = Path.Combine(backupRoot, $"DB_Backup_{timestamp}");
+
+        try 
+        {
+            if (Directory.Exists(dbSource))
+            {
+                logger.LogInformation("Creating automated backup at: {Path}", fullDestination);
+                
+                // Ensure the 'backups' root folder exists
+                Directory.CreateDirectory(backupRoot);
+                
+                // Perform the recursive copy
+                CopyDirectoryRecursive(dbSource, fullDestination);
+                
+                logger.LogInformation("Automated database backup completed.");
+            }
+            else
+            {
+                logger.LogWarning("Database source not found at {Path}. Backup aborted.", dbSource);
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Automated backup failed.");
+        }
+    }
+
+    private void CopyDirectoryRecursive(string source, string target)
+    {
+        Directory.CreateDirectory(target);
+        foreach (string file in Directory.GetFiles(source))
+        {
+            File.Copy(file, Path.Combine(target, Path.GetFileName(file)), true);
+        }
+        foreach (string dir in Directory.GetDirectories(source))
+        {
+            CopyDirectoryRecursive(dir, Path.Combine(target, Path.GetFileName(dir)));
+        }
+    }
+}

--- a/ViewModels/ServerControlViewModel.cs
+++ b/ViewModels/ServerControlViewModel.cs
@@ -150,13 +150,19 @@ public class ServerControlViewModel : ViewModelBase
 
                 if (files.Count > 0)
                 {
-                    // Trigger the automated backup within the base directory
-                    CreateAutomatedDatabaseBackup();
-
                     string selectedFile = files[0].Path.LocalPath;
-                    logger.LogInformation("Zip file selected: {FilePath}. Automated database backup initiated.", selectedFile);
                     
-                    // Proceed with update/extraction logic here
+                    // Launch the update window logic
+                    var updateVm = new UpdateProgressViewModel();
+                    var updateWindow = new Views.UpdateProgressWindow 
+                    { 
+                        DataContext = updateVm 
+                    };
+
+                    updateWindow.Show(desktop.MainWindow);
+
+                    // Start the update process and close window when done
+                    await updateVm.StartUpdate(selectedFile, () => updateWindow.Close());
                 }
             }
         }

--- a/ViewModels/ServerControlViewModel.cs
+++ b/ViewModels/ServerControlViewModel.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Reactive;
 using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Platform.Storage;
 using BLIS_NG.Server;
 using Microsoft.Extensions.Logging;
 using ReactiveUI;
@@ -17,6 +18,7 @@ public class ServerControlViewModel : ViewModelBase
 
     public ReactiveCommand<Unit, Unit> StartServerCommand { get; }
     public ReactiveCommand<Unit, Unit> StopServerCommand { get; }
+    public ReactiveCommand<Unit, Unit> SelectZipCommand { get; }
 
     private string _status = string.Empty;
     public string Status
@@ -48,6 +50,7 @@ public class ServerControlViewModel : ViewModelBase
 
         StartServerCommand = ReactiveCommand.Create(HandleStartButtonClick);
         StopServerCommand = ReactiveCommand.Create(HandleStopButtonClick);
+        SelectZipCommand = ReactiveCommand.CreateFromTask(HandleSelectZipClick);
     }
 
     public void HandleStartButtonClick()
@@ -116,6 +119,38 @@ public class ServerControlViewModel : ViewModelBase
         catch (Exception e)
         {
             logger.LogError(e, "Could not open URL in browser: {Url}", url);
+        }
+    }
+
+    private async Task HandleSelectZipClick()
+    {
+        if (Avalonia.Application.Current?.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop 
+            && desktop.MainWindow != null)
+        {
+            // Access the StorageProvider from the TopLevel (Window)
+            var topLevel = Avalonia.Controls.TopLevel.GetTopLevel(desktop.MainWindow);
+            if (topLevel != null)
+            {
+                var files = await topLevel.StorageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
+                {
+                    Title = "Select ZIP File",
+                    FileTypeFilter = new[] 
+                    { 
+                        new FilePickerFileType("ZIP Files") 
+                        { 
+                            Patterns = new[] { "*.zip" } 
+                        } 
+                    },
+                    AllowMultiple = false
+                });
+
+                if (files.Count > 0)
+                {
+                    var selectedPath = files[0].Path.LocalPath;
+                    logger.LogInformation("User selected ZIP file: {FilePath}", selectedPath);
+                    // The file path is now available in selectedPath for your logic
+                }
+            }
         }
     }
 

--- a/ViewModels/UpdateProgressViewModel.cs
+++ b/ViewModels/UpdateProgressViewModel.cs
@@ -1,0 +1,89 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using ReactiveUI;
+using Avalonia.Media;
+using BLIS_NG.Config;
+
+namespace BLIS_NG.ViewModels;
+
+public class UpdateProgressViewModel : ViewModelBase
+{
+    private string _currentStageText = "Initializing...";
+    private string _progressText = "0/4 Stages";
+    private string _statusMessage = "Update In Progress";
+    private int _percent = 0;
+    private IBrush _statusColor = Brushes.Black;
+
+    public string CurrentStageText { get => _currentStageText; set => this.RaiseAndSetIfChanged(ref _currentStageText, value); }
+    public string ProgressText { get => _progressText; set => this.RaiseAndSetIfChanged(ref _progressText, value); }
+    public string StatusMessage { get => _statusMessage; set => this.RaiseAndSetIfChanged(ref _statusMessage, value); }
+    public int Percent { get => _percent; set => this.RaiseAndSetIfChanged(ref _percent, value); }
+    public IBrush StatusColor { get => _statusColor; set => this.RaiseAndSetIfChanged(ref _statusColor, value); }
+
+    public async Task StartUpdate(string zipPath, Action onComplete)
+    {
+        try
+        {
+            // Stage 1: Data Backup
+            UpdateStage(1, "Stage 1: Backing up data...");
+            CreateAutomatedDatabaseBackup();
+            await Task.Delay(1000); // Small buffer for UX
+
+            // Stage 2: Unpacking Zip (Simulation)
+            UpdateStage(2, "Stage 2: Unpacking ZIP file...");
+            await Task.Delay(5000);
+
+            // Stage 3: Installing Package (Simulation)
+            UpdateStage(3, "Stage 3: Installing new package...");
+            await Task.Delay(5000);
+
+            // Stage 4: Migrating Data (Simulation)
+            UpdateStage(4, "Stage 4: Migrating data...");
+            await Task.Delay(5000);
+
+            Percent = 100;
+            StatusMessage = "Update Successful";
+            StatusColor = Brushes.Green;
+        }
+        catch (Exception)
+        {
+            StatusMessage = "Update Failed";
+            StatusColor = Brushes.Red;
+        }
+
+        await Task.Delay(3000); // Wait 3 seconds before closing
+        onComplete();
+    }
+
+    private void UpdateStage(int stage, string text)
+    {
+        CurrentStageText = text;
+        ProgressText = $"{stage}/4 Stages";
+        Percent = (int)((stage - 1) / 4.0 * 100);
+    }
+
+    private void CreateAutomatedDatabaseBackup()
+    {
+        string baseDir = ConfigurationFile.ResolveBaseDirectory();
+        string dbSource = Path.Combine(baseDir, "dbdir");
+        string backupRoot = Path.Combine(baseDir, "backups");
+        string timestamp = DateTime.Now.ToString("yyyyMMdd_HHmmss");
+        string fullDestination = Path.Combine(backupRoot, $"DB_Backup_{timestamp}");
+
+        if (Directory.Exists(dbSource))
+        {
+            Directory.CreateDirectory(backupRoot);
+            CopyDirectoryRecursive(dbSource, fullDestination);
+        }
+    }
+
+    private void CopyDirectoryRecursive(string source, string target)
+    {
+        Directory.CreateDirectory(target);
+        foreach (string file in Directory.GetFiles(source))
+            File.Copy(file, Path.Combine(target, Path.GetFileName(file)), true);
+        foreach (string dir in Directory.GetDirectories(source))
+            CopyDirectoryRecursive(dir, Path.Combine(target, Path.GetFileName(dir)));
+    }
+}

--- a/Views/MainWindow.axaml
+++ b/Views/MainWindow.axaml
@@ -80,8 +80,9 @@
             Grid.ColumnSpan="5"
         >
             <TextBlock Width="240" VerticalAlignment="Center" Text="{Binding Status}"></TextBlock>
-            <Button Width="160" Command="{Binding StartServerCommand}" IsEnabled="{Binding StartBlisEnabled}">Start BLIS</Button>
-            <Button Width="160" Command="{Binding StopServerCommand}" IsEnabled="{Binding StopBlisEnabled}">Stop BLIS</Button>
+            <Button Width="80" Command="{Binding StartServerCommand}" IsEnabled="{Binding StartBlisEnabled}">Start BLIS</Button>
+            <Button Width="80" Command="{Binding StopServerCommand}" IsEnabled="{Binding StopBlisEnabled}">Stop BLIS</Button>
+            <Button Width="160" Command="{Binding SelectZipCommand}" Content="Update with ZIP File" />
         </StackPanel>
     </Grid>
 </Window>

--- a/Views/UpdateProgressWindow.axaml
+++ b/Views/UpdateProgressWindow.axaml
@@ -1,0 +1,30 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:vm="using:BLIS_NG.ViewModels"
+        x:Class="BLIS_NG.Views.UpdateProgressWindow"
+        x:DataType="vm:UpdateProgressViewModel"
+        Title="System Update" Width="400" Height="250"
+        WindowStartupLocation="CenterOwner" CanResize="False">
+    
+    <Border Padding="20">
+        <StackPanel Spacing="15">
+            <TextBlock Text="{Binding CurrentStageText}" 
+                       FontSize="16" 
+                       FontWeight="Bold" 
+                       HorizontalAlignment="Center"/>
+            
+            <TextBlock Text="{Binding ProgressText}" 
+                       HorizontalAlignment="Center"/>
+            
+            <ProgressBar Value="{Binding Percent}" 
+                         Minimum="0" 
+                         Maximum="100" 
+                         Height="20"/>
+            
+            <TextBlock Text="{Binding StatusMessage}" 
+                       HorizontalAlignment="Center" 
+                       FontSize="14" 
+                       Foreground="{Binding StatusColor}"/>
+        </StackPanel>
+    </Border>
+</Window>

--- a/Views/UpdateProgressWindow.axaml.cs
+++ b/Views/UpdateProgressWindow.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace BLIS_NG.Views;
+
+public partial class UpdateProgressWindow : Window
+{
+    public UpdateProgressWindow()
+    {
+        InitializeComponent();
+    }
+}

--- a/packages.lock.json
+++ b/packages.lock.json
@@ -26,6 +26,17 @@
           "Avalonia.X11": "11.3.11"
         }
       },
+      "Avalonia.Diagnostics": {
+        "type": "Direct",
+        "requested": "[11.3.11, )",
+        "resolved": "11.3.11",
+        "contentHash": "gqKcPTGRZG/ocet5vOmQrIpf+gQU4mOS3mVwIisSv1GAKA/+JmNcnp5ouaKikLbdGt7Qcw2ZKl+daMws9y6/mg==",
+        "dependencies": {
+          "Avalonia": "11.3.11",
+          "Avalonia.Controls.ColorPicker": "11.3.11",
+          "Avalonia.Themes.Simple": "11.3.11"
+        }
+      },
       "Avalonia.ReactiveUI": {
         "type": "Direct",
         "requested": "[11.3.9, )",
@@ -79,9 +90,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[10.0.2, )",
-        "resolved": "10.0.2",
-        "contentHash": "sXdDtMf2qcnbygw9OdE535c2lxSxrZP8gO4UhDJ0xiJbl1wIqXS1OTcTDFTIJPOFd6Mhcm8gPEthqWGUxBsTqw=="
+        "requested": "[10.0.4, )",
+        "resolved": "10.0.4",
+        "contentHash": "CCx8ojW3mOL150/LnP0DK7qpMrJEt6xxNCmJFKoX89v1h0FwpsEHqennowGPYDxp6zIkIO4f9PxynjOeLF+1zw=="
       },
       "Serilog.Extensions.Logging": {
         "type": "Direct",
@@ -121,6 +132,15 @@
         "resolved": "11.3.2",
         "contentHash": "qHDToxto1e3hci5YqbG9n0Ty8mlp3zBUN5wT66wKqaDVzXyQ0do3EnRILd4Ke9jpvsktaPpgE0YjEk7hornryQ=="
       },
+      "Avalonia.Controls.ColorPicker": {
+        "type": "Transitive",
+        "resolved": "11.3.11",
+        "contentHash": "2i5dvZcizAtumywPRravU0/0lLsa8F+n3cTyt2ZpXAwnqnE+eeuozl9Q23YnE69BpROC5wXYrjogXhWcUPks4g==",
+        "dependencies": {
+          "Avalonia": "11.3.11",
+          "Avalonia.Remote.Protocol": "11.3.11"
+        }
+      },
       "Avalonia.FreeDesktop": {
         "type": "Transitive",
         "resolved": "11.3.11",
@@ -155,6 +175,14 @@
           "SkiaSharp": "2.88.9",
           "SkiaSharp.NativeAssets.Linux": "2.88.9",
           "SkiaSharp.NativeAssets.WebAssembly": "2.88.9"
+        }
+      },
+      "Avalonia.Themes.Simple": {
+        "type": "Transitive",
+        "resolved": "11.3.11",
+        "contentHash": "vrCD6Kz4nm4dKA7j3s7nTLxdlsQ+ru7iv45FDwRfys0QhrKK4deq40RxUgfREGvFfCNMD2b9EEerieU3uFSTkw==",
+        "dependencies": {
+          "Avalonia": "11.3.11"
         }
       },
       "Avalonia.Win32": {
@@ -329,6 +357,54 @@
         "type": "Transitive",
         "resolved": "0.21.2",
         "contentHash": "ScSMrUrrw8px4kK1Glh0fZv/HQUlg1078bNXNPfRPKQ3WbRzV9HpsydYEOgSoMK5LWICMf2bMwIFH0pGjxjcMA=="
+      }
+    },
+    "net10.0/win-x64": {
+      "Avalonia.Angle.Windows.Natives": {
+        "type": "Transitive",
+        "resolved": "2.1.25547.20250602",
+        "contentHash": "ZL0VLc4s9rvNNFt19Pxm5UNAkmKNylugAwJPX9ulXZ6JWs/l6XZihPWWTyezaoNOVyEPU8YbURtW7XMAtqXH5A=="
+      },
+      "Avalonia.Native": {
+        "type": "Transitive",
+        "resolved": "11.3.11",
+        "contentHash": "21XxwcOCYuf7fSYBsc4sF7CS0xNK80iDFyXyK9L4awnrjZOJjMuNSGiJ2L5+RQQkXnXaB8ECvMAWN3e/9WN3aw==",
+        "dependencies": {
+          "Avalonia": "11.3.11"
+        }
+      },
+      "HarfBuzzSharp.NativeAssets.Linux": {
+        "type": "Transitive",
+        "resolved": "8.3.1.1",
+        "contentHash": "3EZ1mpIiKWRLL5hUYA82ZHteeDIVaEA/Z0rA/wU6tjx6crcAkJnBPwDXZugBSfo8+J3EznvRJf49uMsqYfKrHg=="
+      },
+      "HarfBuzzSharp.NativeAssets.macOS": {
+        "type": "Transitive",
+        "resolved": "8.3.1.1",
+        "contentHash": "jbtCsgftcaFLCA13tVKo5iWdElJScrulLTKJre36O4YQTIlwDtPPqhRZNk+Y0vv4D1gxbscasGRucUDfS44ofQ=="
+      },
+      "HarfBuzzSharp.NativeAssets.Win32": {
+        "type": "Transitive",
+        "resolved": "8.3.1.1",
+        "contentHash": "UsJtQsfAJoFDZrXc4hCUfRPMqccfKZ0iumJ/upcUjz/cmsTgVFGNEL5yaJWmkqsuFYdMWbj/En5/kS4PFl9hBA=="
+      },
+      "SkiaSharp.NativeAssets.Linux": {
+        "type": "Transitive",
+        "resolved": "2.88.9",
+        "contentHash": "cWSaJKVPWAaT/WIn9c8T5uT/l4ETwHxNJTkEOtNKjphNo8AW6TF9O32aRkxqw3l8GUdUo66Bu7EiqtFh/XG0Zg==",
+        "dependencies": {
+          "SkiaSharp": "2.88.9"
+        }
+      },
+      "SkiaSharp.NativeAssets.macOS": {
+        "type": "Transitive",
+        "resolved": "2.88.9",
+        "contentHash": "Nv5spmKc4505Ep7oUoJ5vp3KweFpeNqxpyGDWyeEPTX2uR6S6syXIm3gj75dM0YJz7NPvcix48mR5laqs8dPuA=="
+      },
+      "SkiaSharp.NativeAssets.Win32": {
+        "type": "Transitive",
+        "resolved": "2.88.9",
+        "contentHash": "wb2kYgU7iy84nQLYZwMeJXixvK++GoIuECjU4ECaUKNuflyRlJKyiRhN1MAHswvlvzuvkrjRWlK0Za6+kYQK7w=="
       }
     }
   }


### PR DESCRIPTION
Added a button on the launcher to select the zip file for launcher self-update feature. Once the button is clicked, it pops up a window to choose a specific .zip file from the device. Once a valid .zip file is selected, a mock pop up is opened to show the update process and stage it is currently at. As the first step, database backup is taken (by copying dbdir folder)