### PR TITLE
feat: password validation and strength meter

### DIFF
--- a/ViewModels/PasswordResetViewModel.cs
+++ b/ViewModels/PasswordResetViewModel.cs
@@ -1,6 +1,7 @@
 using System.Reactive;
 using System.Security.Cryptography;
 using System.Text;
+using System.Text.RegularExpressions;
 using ReactiveUI;
 using BLIS_NG.Server;
 
@@ -27,7 +28,15 @@ public class PasswordResetViewModel : ViewModelBase
     public string NewPassword
     {
         get => _newPassword;
-        set => this.RaiseAndSetIfChanged(ref _newPassword, value);
+        set
+        {
+            this.RaiseAndSetIfChanged(ref _newPassword, value);
+            this.RaisePropertyChanged(nameof(PasswordStrength));
+            this.RaisePropertyChanged(nameof(PasswordStrengthLabel));
+            this.RaisePropertyChanged(nameof(PasswordStrengthColor));
+            this.RaisePropertyChanged(nameof(PasswordStrengthWidth));
+            this.RaisePropertyChanged(nameof(PasswordRequirementsMet));
+        }
     }
 
     private string _confirmPassword = string.Empty;
@@ -67,7 +76,65 @@ public class PasswordResetViewModel : ViewModelBase
     public bool IsStep1Visible => CurrentStep == 1;
     public bool IsStep2Visible => CurrentStep == 2;
 
-    // Feedback
+    // ── Password strength ──────────────────────────────────────────────────
+
+    // Returns 0–4 based on how many criteria are met
+    public int PasswordStrength
+    {
+        get
+        {
+            if (string.IsNullOrEmpty(NewPassword)) return 0;
+            int score = 0;
+            if (NewPassword.Length >= 20)                            score++;
+            if (Regex.IsMatch(NewPassword, "[a-z]"))                 score++;
+            if (Regex.IsMatch(NewPassword, "[A-Z]"))                 score++;
+            if (Regex.IsMatch(NewPassword, "[0-9]"))                 score++;
+            if (Regex.IsMatch(NewPassword, "[^a-zA-Z0-9]"))          score++;
+            return score;
+        }
+    }
+
+    public string PasswordStrengthLabel => PasswordStrength switch
+    {
+        0 => "",
+        1 => "Very Weak",
+        2 => "Weak",
+        3 => "Fair",
+        4 => "Strong",
+        5 => "Very Strong",
+        _ => ""
+    };
+
+    public string PasswordStrengthColor => PasswordStrength switch
+    {
+        1 => "#D32F2F",
+        2 => "#F57C00",
+        3 => "#FBC02D",
+        4 => "#388E3C",
+        5 => "#1B5E20",
+        _ => "Transparent"
+    };
+
+    // Width as a fraction of 300px bar (60px per point)
+    public double PasswordStrengthWidth => PasswordStrength * 60.0;
+
+    // True when minimum NIST-aligned requirements are met (length + 2 classes)
+    public bool PasswordRequirementsMet
+    {
+        get
+        {
+            if (NewPassword.Length < 20) return false;
+            int classes = 0;
+            if (Regex.IsMatch(NewPassword, "[a-z]"))        classes++;
+            if (Regex.IsMatch(NewPassword, "[A-Z]"))        classes++;
+            if (Regex.IsMatch(NewPassword, "[0-9]"))        classes++;
+            if (Regex.IsMatch(NewPassword, "[^a-zA-Z0-9]")) classes++;
+            return classes >= 2;
+        }
+    }
+
+    // ── Feedback ───────────────────────────────────────────────────────────
+
     private string _errorMessage = string.Empty;
     public string ErrorMessage
     {
@@ -94,6 +161,8 @@ public class PasswordResetViewModel : ViewModelBase
 
     public Action? CloseDialog { get; set; }
 
+    // ── Constructor ────────────────────────────────────────────────────────
+
     public PasswordResetViewModel(MySqlAdmin mySqlAdmin)
     {
         _mySqlAdmin = mySqlAdmin;
@@ -103,6 +172,8 @@ public class PasswordResetViewModel : ViewModelBase
         CancelCommand          = ReactiveCommand.Create(HandleCancel);
     }
 
+    // ── Helpers ────────────────────────────────────────────────────────────
+
     private static string HashPasswordSha1(string password)
     {
         var salted = password + "This comment should suffice as salt.";
@@ -110,14 +181,42 @@ public class PasswordResetViewModel : ViewModelBase
         return Convert.ToHexString(bytes).ToLowerInvariant();
     }
 
+    private string? ValidatePassword(string password)
+    {
+        if (password.Length < 20)
+            return "Password must be at least 20 characters.";
+
+        int classes = 0;
+        if (Regex.IsMatch(password, "[a-z]"))        classes++;
+        if (Regex.IsMatch(password, "[A-Z]"))        classes++;
+        if (Regex.IsMatch(password, "[0-9]"))        classes++;
+        if (Regex.IsMatch(password, "[^a-zA-Z0-9]")) classes++;
+
+        if (classes < 2)
+            return "Password must include at least 2 character types (uppercase, lowercase, numbers, symbols).";
+
+        return null; // valid
+    }
+
+    // ── Handlers ───────────────────────────────────────────────────────────
+
     private void HandleProceedToVerify()
     {
         ErrorMessage   = string.Empty;
         SuccessMessage = string.Empty;
 
-        if (string.IsNullOrWhiteSpace(Username))    { ErrorMessage = "Username is required.";     return; }
-        if (string.IsNullOrWhiteSpace(NewPassword)) { ErrorMessage = "New password is required."; return; }
-        if (NewPassword != ConfirmPassword)          { ErrorMessage = "Passwords do not match.";   return; }
+        if (string.IsNullOrWhiteSpace(Username))
+            { ErrorMessage = "Username is required."; return; }
+
+        if (string.IsNullOrWhiteSpace(NewPassword))
+            { ErrorMessage = "New password is required."; return; }
+
+        var passwordError = ValidatePassword(NewPassword);
+        if (passwordError is not null)
+            { ErrorMessage = passwordError; return; }
+
+        if (NewPassword != ConfirmPassword)
+            { ErrorMessage = "Passwords do not match."; return; }
 
         CurrentStep = 2;
     }
@@ -127,8 +226,10 @@ public class PasswordResetViewModel : ViewModelBase
         ErrorMessage   = string.Empty;
         SuccessMessage = string.Empty;
 
-        if (string.IsNullOrWhiteSpace(SupervisorUsername)) { ErrorMessage = "Supervisor username is required."; return; }
-        if (string.IsNullOrWhiteSpace(SupervisorPassword)) { ErrorMessage = "Supervisor password is required."; return; }
+        if (string.IsNullOrWhiteSpace(SupervisorUsername))
+            { ErrorMessage = "Supervisor username is required."; return; }
+        if (string.IsNullOrWhiteSpace(SupervisorPassword))
+            { ErrorMessage = "Supervisor password is required."; return; }
 
         var supervisorHash = HashPasswordSha1(SupervisorPassword);
         var verified = await _mySqlAdmin.VerifyHigherRankedUser(SupervisorUsername, supervisorHash);

--- a/Views/ToolsWindow.axaml
+++ b/Views/ToolsWindow.axaml
@@ -3,13 +3,13 @@
         xmlns:vm="using:BLIS_NG.ViewModels"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-        mc:Ignorable="d" d:DesignWidth="480" d:DesignHeight="520"
+        mc:Ignorable="d" d:DesignWidth="480" d:DesignHeight="600"
         x:CompileBindings="True"
         x:DataType="vm:ToolsWindowViewModel"
         x:Class="BLIS_NG.Views.ToolsWindow"
         Title="BLIS Tools"
         Width="480"
-        Height="520"
+        Height="620"
         CanResize="False"
         WindowStartupLocation="CenterOwner">
 
@@ -31,20 +31,50 @@
 
             <!-- Step 1: Target user details -->
             <StackPanel Spacing="10" IsVisible="{Binding IsStep1Visible}">
+
               <StackPanel Spacing="4">
                 <TextBlock>Username to Reset</TextBlock>
                 <TextBox Text="{Binding Username}" Watermark="Enter username"/>
               </StackPanel>
+
+              <!-- Password requirements box -->
+              <Border Background="#E3F2FD" CornerRadius="4" Padding="10">
+                <StackPanel Spacing="4">
+                  <TextBlock FontWeight="SemiBold" Foreground="#0D47A1">Password Requirements</TextBlock>
+                  <TextBlock Foreground="#1565C0" FontSize="12">• At least 20 characters</TextBlock>
+                  <TextBlock Foreground="#1565C0" FontSize="12">• At least 2 of: uppercase, lowercase, numbers, symbols</TextBlock>
+                  <TextBlock Foreground="#1565C0" FontSize="12">• Example symbol characters: ! @ # $ % ^ &amp; *</TextBlock>
+                </StackPanel>
+              </Border>
+
               <StackPanel Spacing="4">
                 <TextBlock>New Password</TextBlock>
                 <TextBox Text="{Binding NewPassword}" PasswordChar="●"
-                         Watermark="Enter new password"/>
+                         Watermark="Enter new password (min. 20 chars)"/>
+
+                <!-- Strength meter -->
+                <StackPanel Spacing="2" IsVisible="{Binding NewPassword, Converter={x:Static StringConverters.IsNotNullOrEmpty}}">
+                  <Grid ColumnDefinitions="*,Auto">
+                    <Border Grid.Column="0" Background="#E0E0E0" CornerRadius="3" Height="6">
+                      <Border CornerRadius="3" Height="6"
+                              HorizontalAlignment="Left"
+                              Width="{Binding PasswordStrengthWidth}"
+                              Background="{Binding PasswordStrengthColor}"/>
+                    </Border>
+                    <TextBlock Grid.Column="1" Margin="8 0 0 0"
+                               FontSize="11" FontWeight="SemiBold"
+                               Foreground="{Binding PasswordStrengthColor}"
+                               Text="{Binding PasswordStrengthLabel}"/>
+                  </Grid>
+                </StackPanel>
               </StackPanel>
+
               <StackPanel Spacing="4">
                 <TextBlock>Confirm Password</TextBlock>
                 <TextBox Text="{Binding ConfirmPassword}" PasswordChar="●"
                          Watermark="Confirm new password"/>
               </StackPanel>
+
             </StackPanel>
 
             <!-- Step 2: Supervisor verification -->


### PR DESCRIPTION
Adds a tabbed Tools Window to house admin features, replacing the standalone password reset dialog.

Password reset now requires a higher-ranked supervisor to enter their credentials before a reset can execute. Password validation enforces a minimum of 20 characters and at least 2 character classes (uppercase, lowercase, numbers, symbols), per NIST SP 800-63B guidance. A live strength meter displays feedback as the user types.

TODO: confirm user_rank column name in DB schema with team before merging. 
The SQL query uses a column called user_rank, but we don't actually know if that's the real column name in the BLIS database ; I made a reasonable guess. The TODO is a reminder to verify that before merging.